### PR TITLE
#DataFlow-개발/1857 - S3, S3 Parquet sink 노드 메타 통합

### DIFF
--- a/en/node-config-guide.md
+++ b/en/node-config-guide.md
@@ -1369,7 +1369,7 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 2022-11-21T07:49:20.000Z f207c24a122e %{message}
 ```
 
-### Parquet codec Property Description
+### Parquet Codec Property Description
 
 | Property name | Default value | Data type | Description | Note |
 | --- | --- | --- | --- | --- |
@@ -1494,7 +1494,7 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 
 * Same with OBS.
 
-### Parquet codec Property Description
+### Parquet Codec Property Description
 
 | Property name | Default value | Data type | Description | Note |
 | --- | --- | --- | --- | --- |

--- a/en/node-config-guide.md
+++ b/en/node-config-guide.md
@@ -1369,6 +1369,12 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 2022-11-21T07:49:20.000Z f207c24a122e %{message}
 ```
 
+### Parquet codec Property Description
+
+| Property name | Default value | Data type | Description | Note |
+| --- | --- | --- | --- | --- |
+| parquet compression codec | SNAPPY | enum | Enter the compression codec to use when converting PARQUET files. | [Reference](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 ### Prefix Example - Field
 
 #### Condition
@@ -1456,13 +1462,6 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
     * Base time: 60 min
   * Encoding fixed to none
 
-### Property Description
-
-| Property name | Default value | Data type | Description | Note |
-| --- | --- | --- | --- | --- |
-| parquet compression codec | SNAPPY | enum |  
-Enter the compression codec to use when converting PARQUET files. | [Reference](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
-
 ## Sink > (Amazon) S3
 
 ### Node Description
@@ -1495,6 +1494,12 @@ Enter the compression codec to use when converting PARQUET files. | [Reference](
 
 * Same with OBS.
 
+### Parquet codec Property Description
+
+| Property name | Default value | Data type | Description | Note |
+| --- | --- | --- | --- | --- |
+| parquet compression codec | SNAPPY | enum | Enter the compression codec to use when converting PARQUET files. | [Reference](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 ### Additional Settings example
 
 #### follow redirects
@@ -1526,25 +1531,6 @@ Enter the compression codec to use when converting PARQUET files. | [Reference](
     force_path_style → true 
 }
 ```
-
-## Sink > (Amazon) S3 - Parquet
-
-### Node Description
-
-* This node converts data to the parquet type and uploads it to Amazon S3.
-* (Amazon) S3 node, but some values are changed to support the parquet type, as shown below.
-  * Codec fixed to parquet
-* When the object rotation policy is not entered, the default policy is applied as follows.
-    * Object size: 128 MB (134,217,728 bytes)
-    * Base time: 60 min
-  * Encoding fixed to none
-
-### Property Description
-
-| Property name | Default value | Data type | Description | Note |
-| --- | --- | --- | --- | --- |
-| parquet compression codec | SNAPPY | enum |  
-Enter the compression codec to use when converting PARQUET files. | [Reference](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
 
 ## Sink > (Apache) Kafka
 

--- a/ja/node-config-guide.md
+++ b/ja/node-config-guide.md
@@ -1354,6 +1354,12 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 }
 ```
 
+### Parquetコーデック プロパティ説明
+
+| プロパティ名 | デフォルト値 | データ型 | 説明 | 備考 |
+| --- | --- | --- | --- | --- |
+| parquet圧縮コーデック | SNAPPY | enum | parquetファイル変換時に使用する圧縮コーデックを入力します。 | [参照](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 #### 出力値
 
 * パス
@@ -1441,26 +1447,6 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 /obs-test-container/_failure/ls.s3.d53c090b-9718-4833-926a-725b20c85974.2022-11-21T00.47.part0.txt
 ```
 
-## Sink > (NHN Cloud) Object Storage - Parquet
-
-### ノード説明
-
-* NHN CloudのObject Storageにデータをparquetタイプに変換してアップロードするノードです。
-* OBSに作成されるオブジェクトは基本的に次のパス形式に合わせて出力されます。
-    * `/{container_name}/year={yyyy}/month={MM}/day={dd}/hour={HH}/ls.s3.{uuid}.{yyyy}-{MM}-{dd}T{HH}.{mm}.part{seq_id}.parquet`
-* (NHN Cloud) Object Storageノードと同じですが、parquetタイプをサポートするため、一部の値が下記のように変更されます。
-  * コーデックがparquetに固定
-  * オブジェクトローテーションポリシーを入力しない場合、下記のように基本ポリシーが適用されます。
-    * オブジェクトサイズ: 128MB(134,217,728 byte)
-    * 基準時刻: 60分
-  * エンコードはnoneに固定
-
-### プロパティ説明
-
-| プロパティ名 | デフォルト値 | データ型 | 説明 | 備考 |
-| --- | --- | --- | --- | --- |
-| parquet圧縮コーデック | SNAPPY | enum | parquetファイル変換時に使用する圧縮コーデックを入力します。 | [参照](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
-
 ## (Amazon) S3
 
 ### ノードの説明
@@ -1493,6 +1479,12 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 
 * OBSと同じです。
 
+### Parquet コーデック プロパティ説明
+
+| プロパティ名 | デフォルト値 | データ型 | 説明 | 備考 |
+| --- | --- | --- | --- | --- |
+| parquet圧縮コーデック | SNAPPY | enum | parquetファイル変換時に使用する圧縮コーデックを入力します。 | [参照](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 ### 追加設定の例
 
 #### follow redirects
@@ -1524,24 +1516,6 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
     force_path_style → true
 }
 ```
-
-## Sink > (Amazon) S3 - Parquet
-
-### ノードの説明
-
-* データをparquetタイプに変換してAmazon S3にアップロードするノードです。
-* (Amazon) S3ノードと同じですが、parquetタイプをサポートするため、一部の値が下記のように変更されます。
-  * コーデックがparquetに固定
-  * オブジェクトローテーションポリシーを入力しない場合、下記のように基本ポリシーが適用されます。
-    * 基準オブジェクトサイズ: 128MB(134,217,728 byte)
-    * 基準時刻: 60分
-  * エンコードはnoneに固定
-
-### プロパティの説明
-
-| プロパティ名 | デフォルト値 | データ型 | 説明 | 備考 |
-| --- | --- | --- | --- | --- |
-| parquet圧縮コーデック | SNAPPY | enum | parquetファイル変換時に使用する圧縮コーデックを入力します。 | [参照](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
 
 ## Sink > (Apache) Kafka
 

--- a/ko/node-config-guide.md
+++ b/ko/node-config-guide.md
@@ -1369,6 +1369,12 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 2022-11-21T07:49:20.000Z f207c24a122e %{message}
 ```
 
+### Parquet 코덱 속성 설명
+
+| 속성명 | 기본값 | 자료형 | 설명 | 비고 |
+| --- | --- | --- | --- | --- |
+| parquet 압축 코덱 | SNAPPY | enum | parquet 파일 변환 시 사용할 압축 코덱을 입력합니다. | [참조](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 ### Prefix 예시 - 필드
 
 #### 조건
@@ -1442,26 +1448,6 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 /obs-test-container/_failure/ls.s3.d53c090b-9718-4833-926a-725b20c85974.2022-11-21T00.47.part0.txt
 ```
 
-## Sink > (NHN Cloud) Object Storage - Parquet
-
-### 노드 설명
-
-* NHN Cloud의 Object Storage에 데이터를 parquet 타입으로 변환하여 업로드하는 노드입니다.
-* OBS에 작성되는 오브젝트는 기본적으로 다음 경로 포맷에 맞게 출력됩니다.
-    * `/{container_name}/year={yyyy}/month={MM}/day={dd}/hour={HH}/ls.s3.{uuid}.{yyyy}-{MM}-{dd}T{HH}.{mm}.part{seq_id}.parquet`
-* (NHN Cloud) Object Storage 노드와 동일하나 parquet 타입 지원을 위해 일부 값들이 아래와 같이 변경됩니다.
-  * 코덱이 parquet으로 고정
-  * 오브젝트 로테이션 정책 미입력 시 아래와 같이 기본 정책을 적용합니다.
-    * 기준 오브젝트 크기: 128MB(134,217,728 byte)
-    * 기준 시각: 60분
-  * 인코딩은 none으로 고정
-
-### 속성 설명
-
-| 속성명 | 기본값 | 자료형 | 설명 | 비고 |
-| --- | --- | --- | --- | --- |
-| parquet 압축 코덱 | SNAPPY | enum | parquet 파일 변환 시 사용할 압축 코덱을 입력합니다. | [참조](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
-
 ## Sink > (Amazon) S3
 
 ### 노드 설명
@@ -1494,6 +1480,12 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
 
 * OBS와 동일합니다.
 
+### Parquet 코덱 속성 설명
+
+| 속성명 | 기본값 | 자료형 | 설명 | 비고 |
+| --- | --- | --- | --- | --- |
+| parquet 압축 코덱 | SNAPPY | enum | parquet 파일 변환 시 사용할 압축 코덱을 입력합니다. | [참조](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
+
 ### 추가 설정 예시
 
 #### follow redirects
@@ -1525,24 +1517,6 @@ SELECT * FROM MY_TABLE WHERE id > :sql_last_value and id > custom_value order by
     force_path_style → true
 }
 ```
-
-## Sink > (Amazon) S3 - Parquet
-
-### 노드 설명
-
-* Amazon S3에 데이터를 parquet 타입으로 변환하여 업로드하는 노드입니다.
-* (Amazon) S3 노드와 동일하나 parquet 타입 지원을 위해 일부 값들이 아래와 같이 변경됩니다.
-  * 코덱이 parquet으로 고정
-  * 오브젝트 로테이션 정책 미입력 시 아래와 같이 기본 정책을 적용합니다.
-    * 기준 오브젝트 크기: 128MB(134,217,728 byte)
-    * 기준 시각: 60분
-  * 인코딩은 none으로 고정
-
-### 속성 설명
-
-| 속성명 | 기본값 | 자료형 | 설명 | 비고 |
-| --- | --- | --- | --- | --- |
-| parquet 압축 코덱 | SNAPPY | enum | parquet 파일 변환 시 사용할 압축 코덱을 입력합니다. | [참조](https://parquet.apache.org/docs/file-format/data-pages/compression/) |
 
 ## Sink > (Apache) Kafka
 


### PR DESCRIPTION
## 두레이 태스크

* https://nhnent.dooray.com/project/projects/DataFlow-개발/1857

## 작업 내용
- S3, OBS parquet 노드 가이드 제거
- parquet 속성 설명을 S3, OBS 노드로 이전
